### PR TITLE
Default Search Engine changes

### DIFF
--- a/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.html
+++ b/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.html
@@ -9,15 +9,18 @@
     </settings-dropdown-menu>
   </div>
 </template>
-<template is="dom-if" if="[[shouldShowSearchSuggestToggle_()]]" restamp>
+<!-- <template is="dom-if" if="[[shouldShowSearchSuggestToggle_()]]" restamp>
   <settings-toggle-button id="searchSuggestToggle"
       class="hr"
       pref="{{prefs.search.suggest_enabled}}"
       label="$i18n{searchSuggestPref}"
       sub-label="$i18n{searchSuggestPrefDesc}">
   </settings-toggle-button>
-</template>
-<if expr="enable_extensions">
+</template> -->
+
+<!-- commented the html structure code for the search engine page of the settings page. -->
+
+<!-- <if expr="enable_extensions">
 <settings-toggle-button id="webDiscoveryEnabled"
     class="cr-row"
     pref="{{prefs.brave.web_discovery_enabled}}"
@@ -31,4 +34,4 @@
     pref="{{prefs.brave.other_search_engines_enabled}}"
     label="$i18n{otherSearchEnginesControlLabel}"
     sub-label="$i18n{otherSearchEnginesControlDesc}">
-</settings-toggle-button>
+</settings-toggle-button> -->

--- a/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.html
+++ b/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.html
@@ -28,8 +28,8 @@
     sub-label="$i18n{braveWebDiscoverySubLabel}"
     learn-more-url="$i18n{webDiscoveryLearnMoreURL}">
 </settings-toggle-button>
-</if>
-<settings-toggle-button id="otherSearchEnginesEnabled"
+</if>-->
+<!--<settings-toggle-button id="otherSearchEnginesEnabled"
     class="cr-row"
     pref="{{prefs.brave.other_search_engines_enabled}}"
     label="$i18n{otherSearchEnginesControlLabel}"

--- a/browser/search_engines/search_engine_provider_util.cc
+++ b/browser/search_engines/search_engine_provider_util.cc
@@ -25,7 +25,7 @@ namespace brave {
 
 void SetBraveAsDefaultPrivateSearchProvider(PrefService* prefs) {
   auto data = TemplateURLPrepopulateData::GetPrepopulatedEngine(
-      prefs, TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_BRAVE);
+      prefs, TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_GOOGLE);
   DCHECK(data);
   prefs->SetString(prefs::kSyncedDefaultPrivateSearchProviderGUID,
                    data->sync_guid);

--- a/components/search_engines/brave_prepopulated_engines.cc
+++ b/components/search_engines/brave_prepopulated_engines.cc
@@ -37,7 +37,7 @@ PrepopulatedEngine MakeBravePrepopulatedEngine(const wchar_t* const name,
 // Maps BravePrepopulatedEngineID to Chromium's PrepopulatedEngine.
 const std::map<BravePrepopulatedEngineID, const PrepopulatedEngine*>
     brave_engines_map = {
-        {PREPOPULATED_ENGINE_ID_GOOGLE, &google},
+        {PREPOPULATED_ENGINE_ID_GOOGLE, &brave_search},
         {PREPOPULATED_ENGINE_ID_YANDEX, &brave_yandex},
         {PREPOPULATED_ENGINE_ID_BING, &brave_bing},
         {PREPOPULATED_ENGINE_ID_NAVER, &naver},
@@ -48,7 +48,7 @@ const std::map<BravePrepopulatedEngineID, const PrepopulatedEngine*>
         {PREPOPULATED_ENGINE_ID_QWANT, &qwant},
         {PREPOPULATED_ENGINE_ID_STARTPAGE, &startpage},
         {PREPOPULATED_ENGINE_ID_ECOSIA, &brave_ecosia},
-        {PREPOPULATED_ENGINE_ID_BRAVE, &brave_search},
+        {PREPOPULATED_ENGINE_ID_BRAVE, &google}, //changed &brave_search to &google and brave is now replaced by google from all the places. TODO:permanent solution for it
 };
 
 PrepopulatedEngine ModifyEngineParams(const PrepopulatedEngine& engine,


### PR DESCRIPTION
Changed the default search engine from Brave Search to Google Search for both private as well as normal search.

(In the settings page under search engine tab, in normal window Default search engine selector, Learn more hyperlink is still visible as this is coming from the chromium code)