### PR TITLE
Removed Tor section in settings and by default disabled support for Tor

### DIFF
--- a/browser/resources/settings/brave_overrides/basic_page.ts
+++ b/browser/resources/settings/brave_overrides/basic_page.ts
@@ -327,7 +327,7 @@ RegisterPolymerTemplateModifications({
       // Insert Web3 Domains
       last = last.insertAdjacentElement('afterend', sectionWeb3Domains)
       // Insert Tor
-      last = last.insertAdjacentElement('afterend', sectionTor)
+      // last = last.insertAdjacentElement('afterend', sectionTor)
       // Insert Leo Assistant
       last = last.insertAdjacentElement('afterend', sectionLeoAssist)
 

--- a/components/tor/pref_names.cc
+++ b/components/tor/pref_names.cc
@@ -7,6 +7,7 @@
 
 namespace tor::prefs {
 
+//Tor disabled by default. originally "tor.tor_disabled"
 const char kTorDisabled[] = "false";
 
 const char kAutoOnionRedirect[] = "tor.auto_onion_location";

--- a/components/tor/pref_names.cc
+++ b/components/tor/pref_names.cc
@@ -7,7 +7,7 @@
 
 namespace tor::prefs {
 
-const char kTorDisabled[] = "tor.tor_disabled";
+const char kTorDisabled[] = "false";
 
 const char kAutoOnionRedirect[] = "tor.auto_onion_location";
 const char kBridgesConfig[] = "tor.bridges";


### PR DESCRIPTION
1. Removed Tor section in settings
2. Disabled support for Tor by default
![Screenshot_20240407_010737](https://github.com/Ping-browser/ping-core/assets/40711348/30268c2a-d687-4ca8-a7a4-d59cd389f7d0)
![WhatsApp Image 2024-04-07 at 1 07 57 AM](https://github.com/Ping-browser/ping-core/assets/40711348/18fe02ed-4758-4951-9fde-596a22f4b675)
