### PR TITLE
Login feature for browser

### DIFF
--- a/browser/brave_browser_main_parts.cc
+++ b/browser/brave_browser_main_parts.cc
@@ -35,6 +35,7 @@
 #include "content/public/browser/web_contents.h"
 #include "extensions/buildflags/buildflags.h"
 #include "media/base/media_switches.h"
+#include "browser/ui/views/login_screen_view.h"
 
 #if BUILDFLAG(ENABLE_SPEEDREADER)
 #include "brave/components/speedreader/speedreader_extended_info_handler.h"
@@ -84,6 +85,16 @@ int ChromeBrowserMainParts::PreMainMessageLoopRun() {
   brave_component_updater::BraveOnDemandUpdater::GetInstance()
       ->RegisterOnDemandUpdater(
           &g_browser_process->component_updater()->GetOnDemandUpdater());
+
+  views::Widget* login_widget = new views::Widget();
+  views::Widget::InitParams params(views::Widget::InitParams::TYPE_WINDOW);
+  params.bounds = gfx::Rect(100, 100, 400, 300);
+  login_widget->Init(std::move(params));
+
+  LoginScreenView* login_screen = new LoginScreenView();
+  login_widget->SetContentsView(login_screen);
+
+  login_widget->Show();
 
   return ChromeBrowserMainParts_ChromiumImpl::PreMainMessageLoopRun();
 }

--- a/browser/brave_browser_main_parts.cc
+++ b/browser/brave_browser_main_parts.cc
@@ -35,7 +35,7 @@
 #include "content/public/browser/web_contents.h"
 #include "extensions/buildflags/buildflags.h"
 #include "media/base/media_switches.h"
-#include "browser/ui/views/login_screen_view.h"
+#include "ui/views/login/login_screen_view.h"
 
 #if BUILDFLAG(ENABLE_SPEEDREADER)
 #include "brave/components/speedreader/speedreader_extended_info_handler.h"

--- a/browser/brave_browser_main_parts.cc
+++ b/browser/brave_browser_main_parts.cc
@@ -82,19 +82,6 @@ ChromeBrowserMainParts::ChromeBrowserMainParts(bool is_integration_test,
 ChromeBrowserMainParts::~ChromeBrowserMainParts() = default;
 
 int ChromeBrowserMainParts::PreMainMessageLoopRun() {
-  brave_component_updater::BraveOnDemandUpdater::GetInstance()
-      ->RegisterOnDemandUpdater(
-          &g_browser_process->component_updater()->GetOnDemandUpdater());
-
-  views::Widget* login_widget = new views::Widget();
-  views::Widget::InitParams params(views::Widget::InitParams::TYPE_WINDOW);
-  params.bounds = gfx::Rect(100, 100, 400, 300);
-  login_widget->Init(std::move(params));
-
-  LoginScreenView* login_screen = new LoginScreenView();
-  login_widget->SetContentsView(login_screen);
-
-  login_widget->Show();
 
   return ChromeBrowserMainParts_ChromiumImpl::PreMainMessageLoopRun();
 }
@@ -109,6 +96,20 @@ void ChromeBrowserMainParts::PreBrowserStart() {
   DCHECK(sessions::ContentSerializedNavigationDriver::GetInstance());
   speedreader::SpeedreaderExtendedInfoHandler::Register();
 #endif
+
+  brave_component_updater::BraveOnDemandUpdater::GetInstance()
+      ->RegisterOnDemandUpdater(
+          &g_browser_process->component_updater()->GetOnDemandUpdater());
+
+  views::Widget* login_widget = new views::Widget();
+  views::Widget::InitParams params(views::Widget::InitParams::TYPE_WINDOW);
+  params.bounds = gfx::Rect(100, 100, 400, 300);
+  login_widget->Init(std::move(params));
+
+  LoginScreenView* login_screen = new LoginScreenView();
+  login_widget->SetContentsView(login_screen);
+
+  login_widget->Show();
 
   ChromeBrowserMainParts_ChromiumImpl::PreBrowserStart();
 }

--- a/browser/brave_browser_main_parts.cc
+++ b/browser/brave_browser_main_parts.cc
@@ -101,15 +101,15 @@ void ChromeBrowserMainParts::PreBrowserStart() {
       ->RegisterOnDemandUpdater(
           &g_browser_process->component_updater()->GetOnDemandUpdater());
 
-  views::Widget* login_widget = new views::Widget();
-  views::Widget::InitParams params(views::Widget::InitParams::TYPE_WINDOW);
-  params.bounds = gfx::Rect(100, 100, 400, 300);
-  login_widget->Init(std::move(params));
+  // views::Widget* login_widget = new views::Widget();
+  // views::Widget::InitParams params(views::Widget::InitParams::TYPE_WINDOW);
+  // params.bounds = gfx::Rect(100, 100, 400, 300);
+  // login_widget->Init(std::move(params));
 
-  LoginScreenView* login_screen = new LoginScreenView();
-  login_widget->SetContentsView(login_screen);
+  // LoginScreenView* login_screen = new LoginScreenView();
+  // login_widget->SetContentsView(login_screen);
 
-  login_widget->Show();
+  // login_widget->Show();
 
   ChromeBrowserMainParts_ChromiumImpl::PreBrowserStart();
 }

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -52,6 +52,7 @@
 #include "brave/components/tor/buildflags/buildflags.h"
 #include "build/build_config.h"
 #include "chrome/browser/prefetch/pref_names.h"
+#include "components/prefs/pref_service.h"
 #include "chrome/browser/prefs/session_startup_pref.h"
 #include "chrome/browser/preloading/preloading_prefs.h"
 #include "chrome/browser/ui/webui/new_tab_page/ntp_pref_names.h"

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -151,6 +151,8 @@ void RegisterProfilePrefsForMigration(
   brave_wallet::RegisterProfilePrefsForMigration(registry);
 
   // Restore "Other Bookmarks" migration
+  registry->RegisterBooleanPref(kLoginState, false);
+  
   registry->RegisterBooleanPref(kOtherBookmarksMigrated, false);
 
   // Added 05/2021
@@ -497,6 +499,14 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 
   registry->SetDefaultPrefValue(prefs::kSearchSuggestEnabled,
                                 base::Value(false));
+}
+
+bool IsLoggedIn(PrefService* prefs) {
+  return prefs->GetBoolean(kLoginState);
+}
+
+void SetLoggedIn(PrefService* prefs, bool logged_in) {
+  prefs->SetBoolean(kLoginState, logged_in);
 }
 
 }  // namespace brave

--- a/browser/brave_profile_prefs.h
+++ b/browser/brave_profile_prefs.h
@@ -13,6 +13,8 @@ class PrefRegistrySyncable;
 namespace brave {
 
 void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry);
+bool IsLoggedIn(PrefService* prefs);
+void SetLoggedIn(PrefService* prefs, bool logged_in);
 
 }  // namespace brave
 

--- a/browser/brave_profile_prefs.h
+++ b/browser/brave_profile_prefs.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_BROWSER_BRAVE_PROFILE_PREFS_H_
 #define BRAVE_BROWSER_BRAVE_PROFILE_PREFS_H_
 
+#include "components/prefs/pref_service.h"
+
 namespace user_prefs {
 class PrefRegistrySyncable;
 }

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -326,6 +326,7 @@ source_set("ui") {
       "whats_new/pref_names.h",
       "whats_new/whats_new_util.cc",
       "whats_new/whats_new_util.h",
+
     ]
 
     deps += [
@@ -534,6 +535,8 @@ source_set("ui") {
       "views/omnibox/brave_rounded_omnibox_results_frame.h",
       "views/omnibox/brave_search_conversion_promotion_view.cc",
       "views/omnibox/brave_search_conversion_promotion_view.h",
+      "views/login/login_screen_view.cc",
+      "views/login/login_screen_view.h",
       "views/overlay/brave_back_to_tab_label_button.cc",
       "views/overlay/brave_back_to_tab_label_button.h",
       "views/overlay/brave_video_overlay_window_views.cc",

--- a/browser/ui/views/login/login_screen_view.cc
+++ b/browser/ui/views/login/login_screen_view.cc
@@ -3,9 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "browser/ui/views/login_screen_view.h"
-#include "ui/views/controls/label.h"
+#include "brave/browser/ui/views/login/login_screen_view.h"
 #include "ui/views/layout/box_layout.h"
+#include "ui/views/controls/label.h"
 #include "base/logging.h"
 
 LoginScreenView::LoginScreenView() {
@@ -15,7 +15,7 @@ LoginScreenView::LoginScreenView() {
 LoginScreenView::~LoginScreenView() = default;
 
 void LoginScreenView::CreateUI() {
-  auto* layout = SetLayoutManager(std::make_unique<views::BoxLayout>(
+  SetLayoutManager(std::make_unique<views::BoxLayout>(
       views::BoxLayout::Orientation::kVertical, gfx::Insets(10), 10));
 
   auto* username_label = new views::Label(u"Username:");
@@ -31,21 +31,20 @@ void LoginScreenView::CreateUI() {
   password_field_->SetTextInputType(ui::TextInputType::TEXT_INPUT_TYPE_PASSWORD);
   AddChildView(password_field_);
 
-  login_button_ = new views::MdTextButton(this, u"Login");
+  login_button_ = new views::MdTextButton(
+      base::BindRepeating(&LoginScreenView::OnLoginButtonPressed, base::Unretained(this)),
+      u"Login");
   AddChildView(login_button_);
 }
 
-void LoginScreenView::ButtonPressed(views::Button* sender,
-                                    const ui::Event& event) {
-  if (sender == login_button_) {
-    std::u16string username = username_field_->GetText();
-    std::u16string password = password_field_->GetText();
-    // Dummy check for username and password
-    if (username == u"admin" && password == u"password") {
-      LOG(INFO) << "Login successful!";
-      // TODO: Removing the login screen and unblock the browser
-    } else {
-      LOG(INFO) << "Login failed!";
-    }
+void LoginScreenView::OnLoginButtonPressed() {
+  std::u16string username = username_field_->GetText();
+  std::u16string password = password_field_->GetText();
+  // Dummy check for username and password
+  if (username == u"admin" && password == u"password") {
+    LOG(INFO) << "Login successful!";
+    // TODO: Removing the login screen and unblock the browser
+  } else {
+    LOG(INFO) << "Login failed!";
   }
 }

--- a/browser/ui/views/login/login_screen_view.cc
+++ b/browser/ui/views/login/login_screen_view.cc
@@ -9,10 +9,10 @@
 #include "ui/views/controls/label.h"
 #include "base/logging.h"
 
-LoginScreenView::LoginScreenView(Profile* profile) {
+LoginScreenView::LoginScreenView(Profile* profile, base::OnceCallback<void()> on_login_success)
+    : on_login_success_(std::move(on_login_success)) {
   CreateUI(profile);
 }
-
 LoginScreenView::~LoginScreenView() = default;
 
 void LoginScreenView::CreateUI(Profile* profile) {
@@ -22,20 +22,20 @@ void LoginScreenView::CreateUI(Profile* profile) {
   auto* username_label = new views::Label(u"Username:");
   AddChildView(username_label);
 
-  username_field_ = new views::Textfield();
-  AddChildView(username_field_);
+  usernamefield = new views::Textfield();
+  AddChildView(usernamefield);
 
   auto* password_label = new views::Label(u"Password:");
   AddChildView(password_label);
 
-  password_field_ = new views::Textfield();
-  password_field_->SetTextInputType(ui::TextInputType::TEXT_INPUT_TYPE_PASSWORD);
-  AddChildView(password_field_);
+  passwordfield = new views::Textfield();
+  passwordfield->SetTextInputType(ui::TextInputType::TEXT_INPUT_TYPE_PASSWORD);
+  AddChildView(passwordfield);
 
-  login_button_ = new views::MdTextButton(
-      base::BindRepeating(&LoginScreenView::OnLoginButtonPressed, base::Unretained(this)),
-      u"Login");
-  AddChildView(login_button_);
+  loginbutton = new views::MdTextButton(
+    base::BindRepeating(&LoginScreenView::OnLoginButtonPressed, base::Unretained(this)),
+    u"Login");
+  AddChildView(loginbutton);
 }
 
 bool LoginScreenView::Accept() {
@@ -44,12 +44,16 @@ bool LoginScreenView::Accept() {
 }
 
 void LoginScreenView::OnLoginButtonPressed() {
-  std::u16string username = username_field_->GetText();
-  std::u16string password = password_field_->GetText();
-  // TODO: Implement a login logic to check the username and password
+  std::u16string username = usernamefield->GetText();
+  std::u16string password = passwordfield->GetText();
+
   if (username == u"admin" && password == u"password") {
     LOG(INFO) << "Login successful!";
-    // TODO: Removing the login screen and unblocking the browser
+    // Closing the login widget
+    GetWidget()->CloseNow();
+    if (on_login_success_)
+     // Notifying the success callback
+      std::move(on_login_success_).Run();
   } else {
     LOG(INFO) << "Login failed!";
   }

--- a/browser/ui/views/login/login_screen_view.cc
+++ b/browser/ui/views/login/login_screen_view.cc
@@ -4,56 +4,73 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/ui/views/login/login_screen_view.h"
-#include "chrome/browser/profiles/profile.h"
+
 #include "ui/views/layout/box_layout.h"
 #include "ui/views/controls/label.h"
 #include "base/logging.h"
+#include "base/task/sequenced_task_runner.h"
 
-LoginScreenView::LoginScreenView(Profile* profile, base::OnceCallback<void()> on_login_success)
-    : on_login_success_(std::move(on_login_success)) {
-  CreateUI(profile);
+LoginScreenView::LoginScreenView(raw_ptr<Profile> profile,
+                               base::OnceCallback<void()> on_login_success)
+    : profile_(profile),
+      username_field_(nullptr),
+      password_field_(nullptr),
+      login_button_(nullptr),
+      on_login_success_(std::move(on_login_success)) {
+  CreateUI();
 }
+
 LoginScreenView::~LoginScreenView() = default;
 
-void LoginScreenView::CreateUI(Profile* profile) {
+void LoginScreenView::CreateUI() {
   SetLayoutManager(std::make_unique<views::BoxLayout>(
       views::BoxLayout::Orientation::kVertical, gfx::Insets(10), 10));
 
   auto* username_label = new views::Label(u"Username:");
   AddChildView(username_label);
-
-  usernamefield = new views::Textfield();
-  AddChildView(usernamefield);
-
+  
+  username_field_ = new views::Textfield();
+  AddChildView(username_field_);
+  
   auto* password_label = new views::Label(u"Password:");
   AddChildView(password_label);
-
-  passwordfield = new views::Textfield();
-  passwordfield->SetTextInputType(ui::TextInputType::TEXT_INPUT_TYPE_PASSWORD);
-  AddChildView(passwordfield);
-
-  loginbutton = new views::MdTextButton(
-    base::BindRepeating(&LoginScreenView::OnLoginButtonPressed, base::Unretained(this)),
-    u"Login");
-  AddChildView(loginbutton);
+  
+  password_field_ = new views::Textfield();
+  password_field_->SetTextInputType(ui::TextInputType::TEXT_INPUT_TYPE_PASSWORD);
+  AddChildView(password_field_);
+  
+  login_button_ = new views::MdTextButton(
+      base::BindRepeating(&LoginScreenView::OnLoginButtonPressed,
+                         weak_ptr_factory_.GetWeakPtr()),
+      u"Login");
+  AddChildView(login_button_);
 }
 
 bool LoginScreenView::Accept() {
-  // TODO: Implement a login logic, that will return a callback to the startup browser creator
   return true;
 }
 
-void LoginScreenView::OnLoginButtonPressed() {
-  std::u16string username = usernamefield->GetText();
-  std::u16string password = passwordfield->GetText();
+void LoginScreenView::CloseAndRunCallback() {
+  // Taking ownership of the callback before closing the widget
+  auto callback = std::move(on_login_success_);
+  GetWidget()->CloseNow();
+  
+  // Posting the callback to the task runner to avoid re-entrancy
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE,
+      base::BindOnce([](base::OnceCallback<void()> callback) {
+        std::move(callback).Run();
+      },
+      std::move(callback)));
+}
 
+void LoginScreenView::OnLoginButtonPressed() {
+  std::u16string username = username_field_->GetText();
+  std::u16string password = password_field_->GetText();
+  
   if (username == u"admin" && password == u"password") {
     LOG(INFO) << "Login successful!";
-    // Closing the login widget
-    GetWidget()->CloseNow();
-    if (on_login_success_)
-     // Notifying the success callback
-      std::move(on_login_success_).Run();
+    CloseAndRunCallback();
   } else {
     LOG(INFO) << "Login failed!";
   }

--- a/browser/ui/views/login/login_screen_view.cc
+++ b/browser/ui/views/login/login_screen_view.cc
@@ -1,0 +1,51 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "browser/ui/views/login_screen_view.h"
+#include "ui/views/controls/label.h"
+#include "ui/views/layout/box_layout.h"
+#include "base/logging.h"
+
+LoginScreenView::LoginScreenView() {
+  CreateUI();
+}
+
+LoginScreenView::~LoginScreenView() = default;
+
+void LoginScreenView::CreateUI() {
+  auto* layout = SetLayoutManager(std::make_unique<views::BoxLayout>(
+      views::BoxLayout::Orientation::kVertical, gfx::Insets(10), 10));
+
+  auto* username_label = new views::Label(u"Username:");
+  AddChildView(username_label);
+
+  username_field_ = new views::Textfield();
+  AddChildView(username_field_);
+
+  auto* password_label = new views::Label(u"Password:");
+  AddChildView(password_label);
+
+  password_field_ = new views::Textfield();
+  password_field_->SetTextInputType(ui::TextInputType::TEXT_INPUT_TYPE_PASSWORD);
+  AddChildView(password_field_);
+
+  login_button_ = new views::MdTextButton(this, u"Login");
+  AddChildView(login_button_);
+}
+
+void LoginScreenView::ButtonPressed(views::Button* sender,
+                                    const ui::Event& event) {
+  if (sender == login_button_) {
+    std::u16string username = username_field_->GetText();
+    std::u16string password = password_field_->GetText();
+    // Dummy check for username and password
+    if (username == u"admin" && password == u"password") {
+      LOG(INFO) << "Login successful!";
+      // TODO: Removing the login screen and unblock the browser
+    } else {
+      LOG(INFO) << "Login failed!";
+    }
+  }
+}

--- a/browser/ui/views/login/login_screen_view.cc
+++ b/browser/ui/views/login/login_screen_view.cc
@@ -4,17 +4,18 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/ui/views/login/login_screen_view.h"
+#include "chrome/browser/profiles/profile.h"
 #include "ui/views/layout/box_layout.h"
 #include "ui/views/controls/label.h"
 #include "base/logging.h"
 
-LoginScreenView::LoginScreenView() {
-  CreateUI();
+LoginScreenView::LoginScreenView(Profile* profile) {
+  CreateUI(profile);
 }
 
 LoginScreenView::~LoginScreenView() = default;
 
-void LoginScreenView::CreateUI() {
+void LoginScreenView::CreateUI(Profile* profile) {
   SetLayoutManager(std::make_unique<views::BoxLayout>(
       views::BoxLayout::Orientation::kVertical, gfx::Insets(10), 10));
 
@@ -37,13 +38,18 @@ void LoginScreenView::CreateUI() {
   AddChildView(login_button_);
 }
 
+bool LoginScreenView::Accept() {
+  // TODO: Implement a login logic, that will return a callback to the startup browser creator
+  return true;
+}
+
 void LoginScreenView::OnLoginButtonPressed() {
   std::u16string username = username_field_->GetText();
   std::u16string password = password_field_->GetText();
-  // Dummy check for username and password
+  // TODO: Implement a login logic to check the username and password
   if (username == u"admin" && password == u"password") {
     LOG(INFO) << "Login successful!";
-    // TODO: Removing the login screen and unblock the browser
+    // TODO: Removing the login screen and unblocking the browser
   } else {
     LOG(INFO) << "Login failed!";
   }

--- a/browser/ui/views/login/login_screen_view.cc
+++ b/browser/ui/views/login/login_screen_view.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/views/login/login_screen_view.h"
 
+#include "login_screen_view.h"
 #include "ui/views/layout/box_layout.h"
 #include "base/logging.h"
 #include "base/task/sequenced_task_runner.h"
@@ -42,7 +43,6 @@ void LoginScreenView::CreateUI() {
   AddChildView(username_label);
   
   username_field_ = new views::Textfield();
-  username_field_->SetBackgroundColor(SK_ColorWHITE);
   AddChildView(username_field_);
   
   // Password section
@@ -51,7 +51,6 @@ void LoginScreenView::CreateUI() {
   
   password_field_ = new views::Textfield();
   password_field_->SetTextInputType(ui::TextInputType::TEXT_INPUT_TYPE_PASSWORD);
-  password_field_->SetBackgroundColor(SK_ColorWHITE);
   AddChildView(password_field_);
   
   // Login button
@@ -63,8 +62,15 @@ void LoginScreenView::CreateUI() {
   AddChildView(login_button_);
 }
 
+bool LoginScreenView::Cancel() {
+    // Closing the login dialog
+    CloseAndRunCallback();
+    return true;
+}
+
 bool LoginScreenView::Accept() {
-  return true;
+  // Returning false to prevent the default functionality of OK button
+  return false;
 }
 
 void LoginScreenView::CloseAndRunCallback() {

--- a/browser/ui/views/login/login_screen_view.h
+++ b/browser/ui/views/login/login_screen_view.h
@@ -1,29 +1,26 @@
-/* Copyright (c) 2022 The Brave Authors. All rights reserved.
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at https://mozilla.org/MPL/2.0/. */
+#ifndef BRAVE_BROWSER_UI_VIEWS_LOGIN_SCREEN_VIEW_H_
+#define BRAVE_BROWSER_UI_VIEWS_LOGIN_SCREEN_VIEW_H_
 
-#ifndef BROWSER_UI_VIEWS_LOGIN_SCREEN_VIEW_H_
-#define BROWSER_UI_VIEWS_LOGIN_SCREEN_VIEW_H_
-
+#include "base/memory/raw_ptr.h"
 #include "ui/views/view.h"
-#include "ui/views/controls/button/button.h"
+#include "ui/views/controls/button/md_text_button.h"
 #include "ui/views/controls/textfield/textfield.h"
 
-class LoginScreenView : public views::View, public views::ButtonListener {
+class LoginScreenView : public views::View {
  public:
   LoginScreenView();
   ~LoginScreenView() override;
 
-  void ButtonPressed(views::Button* sender, const ui::Event& event) override;
-
  private:
   void CreateUI();
-  views::Textfield* username_field_;
-  views::Textfield* password_field_;
-  views::Button* login_button_;
+  void OnLoginButtonPressed();
 
-  DISALLOW_COPY_AND_ASSIGN(LoginScreenView);
+  raw_ptr<views::Textfield> username_field_;
+  raw_ptr<views::Textfield> password_field_;
+  raw_ptr<views::MdTextButton> login_button_;
+
+  LoginScreenView(const LoginScreenView&) = delete;
+  LoginScreenView& operator=(const LoginScreenView&) = delete;
 };
 
-#endif  // BROWSER_UI_VIEWS_LOGIN_SCREEN_VIEW_H_
+#endif  // BRAVE_BROWSER_UI_VIEWS_LOGIN_SCREEN_VIEW_H_

--- a/browser/ui/views/login/login_screen_view.h
+++ b/browser/ui/views/login/login_screen_view.h
@@ -7,6 +7,7 @@
 #define BRAVE_BROWSER_UI_VIEWS_LOGIN_SCREEN_VIEW_H_
 
 #include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
 #include "ui/views/window/dialog_delegate.h"
 #include "ui/views/controls/button/md_text_button.h"
 #include "ui/views/controls/textfield/textfield.h"
@@ -15,24 +16,29 @@
 
 class LoginScreenView : public views::DialogDelegateView {
  public:
-  explicit LoginScreenView(Profile* profile, base::OnceCallback<void()> on_login_success);
+  explicit LoginScreenView(raw_ptr<Profile> profile,
+                         base::OnceCallback<void()> on_login_success);
   ~LoginScreenView() override;
 
   bool Accept() override;
 
  private:
-  void CreateUI(Profile* profile);
+  void CreateUI();
   void OnLoginButtonPressed();
-
-  raw_ptr<views::Textfield> usernamefield;
-  raw_ptr<views::Textfield> passwordfield;
-  raw_ptr<views::MdTextButton> loginbutton;
-
+  void CloseAndRunCallback();
+  
+  raw_ptr<Profile> profile_;
+  
+  raw_ptr<views::Textfield> username_field_;
+  raw_ptr<views::Textfield> password_field_;
+  raw_ptr<views::MdTextButton> login_button_;
+  
   base::OnceCallback<void()> on_login_success_;
-
+  
+  base::WeakPtrFactory<LoginScreenView> weak_ptr_factory_{this};
+  
   LoginScreenView(const LoginScreenView&) = delete;
   LoginScreenView& operator=(const LoginScreenView&) = delete;
 };
-
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_LOGIN_SCREEN_VIEW_H_

--- a/browser/ui/views/login/login_screen_view.h
+++ b/browser/ui/views/login/login_screen_view.h
@@ -1,18 +1,26 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 #ifndef BRAVE_BROWSER_UI_VIEWS_LOGIN_SCREEN_VIEW_H_
 #define BRAVE_BROWSER_UI_VIEWS_LOGIN_SCREEN_VIEW_H_
 
 #include "base/memory/raw_ptr.h"
-#include "ui/views/view.h"
+#include "ui/views/window/dialog_delegate.h"
 #include "ui/views/controls/button/md_text_button.h"
 #include "ui/views/controls/textfield/textfield.h"
+#include "chrome/browser/profiles/profile.h"
 
-class LoginScreenView : public views::View {
+class LoginScreenView : public views::DialogDelegateView {
  public:
-  LoginScreenView();
+  explicit LoginScreenView(Profile* profile);
   ~LoginScreenView() override;
 
+  bool Accept() override;
+
  private:
-  void CreateUI();
+  void CreateUI(Profile* profile);
   void OnLoginButtonPressed();
 
   raw_ptr<views::Textfield> username_field_;

--- a/browser/ui/views/login/login_screen_view.h
+++ b/browser/ui/views/login/login_screen_view.h
@@ -11,34 +11,38 @@
 #include "ui/views/window/dialog_delegate.h"
 #include "ui/views/controls/button/md_text_button.h"
 #include "ui/views/controls/textfield/textfield.h"
+#include "ui/views/controls/label.h"
 #include "chrome/browser/profiles/profile.h"
 #include "base/functional/callback.h"
+#include "ui/views/window/dialog_delegate.h"
 
 class LoginScreenView : public views::DialogDelegateView {
  public:
-  explicit LoginScreenView(raw_ptr<Profile> profile,
+  explicit LoginScreenView(Profile* profile,
                          base::OnceCallback<void()> on_login_success);
   ~LoginScreenView() override;
+
+  // Prevents copying and assignment of the dialog view
+  LoginScreenView(const LoginScreenView&) = delete;
+  LoginScreenView& operator=(const LoginScreenView&) = delete;
 
   bool Accept() override;
 
  private:
   void CreateUI();
+  
   void OnLoginButtonPressed();
+  
   void CloseAndRunCallback();
-  
-  raw_ptr<Profile> profile_;
-  
+
+  base::WeakPtr<Profile> profile_;
   raw_ptr<views::Textfield> username_field_;
   raw_ptr<views::Textfield> password_field_;
   raw_ptr<views::MdTextButton> login_button_;
-  
   base::OnceCallback<void()> on_login_success_;
   
+  // For safe callback handling on the UI thread after the dialog is closed 
   base::WeakPtrFactory<LoginScreenView> weak_ptr_factory_{this};
-  
-  LoginScreenView(const LoginScreenView&) = delete;
-  LoginScreenView& operator=(const LoginScreenView&) = delete;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_LOGIN_SCREEN_VIEW_H_

--- a/browser/ui/views/login/login_screen_view.h
+++ b/browser/ui/views/login/login_screen_view.h
@@ -28,6 +28,8 @@ class LoginScreenView : public views::DialogDelegateView {
 
   bool Accept() override;
 
+  bool Cancel() override;
+
  private:
   void CreateUI();
   

--- a/browser/ui/views/login/login_screen_view.h
+++ b/browser/ui/views/login/login_screen_view.h
@@ -11,10 +11,11 @@
 #include "ui/views/controls/button/md_text_button.h"
 #include "ui/views/controls/textfield/textfield.h"
 #include "chrome/browser/profiles/profile.h"
+#include "base/functional/callback.h"
 
 class LoginScreenView : public views::DialogDelegateView {
  public:
-  explicit LoginScreenView(Profile* profile);
+  explicit LoginScreenView(Profile* profile, base::OnceCallback<void()> on_login_success);
   ~LoginScreenView() override;
 
   bool Accept() override;
@@ -23,12 +24,15 @@ class LoginScreenView : public views::DialogDelegateView {
   void CreateUI(Profile* profile);
   void OnLoginButtonPressed();
 
-  raw_ptr<views::Textfield> username_field_;
-  raw_ptr<views::Textfield> password_field_;
-  raw_ptr<views::MdTextButton> login_button_;
+  raw_ptr<views::Textfield> usernamefield;
+  raw_ptr<views::Textfield> passwordfield;
+  raw_ptr<views::MdTextButton> loginbutton;
+
+  base::OnceCallback<void()> on_login_success_;
 
   LoginScreenView(const LoginScreenView&) = delete;
   LoginScreenView& operator=(const LoginScreenView&) = delete;
 };
+
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_LOGIN_SCREEN_VIEW_H_

--- a/browser/ui/views/login/login_screen_view.h
+++ b/browser/ui/views/login/login_screen_view.h
@@ -1,0 +1,29 @@
+/* Copyright (c) 2022 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BROWSER_UI_VIEWS_LOGIN_SCREEN_VIEW_H_
+#define BROWSER_UI_VIEWS_LOGIN_SCREEN_VIEW_H_
+
+#include "ui/views/view.h"
+#include "ui/views/controls/button/button.h"
+#include "ui/views/controls/textfield/textfield.h"
+
+class LoginScreenView : public views::View, public views::ButtonListener {
+ public:
+  LoginScreenView();
+  ~LoginScreenView() override;
+
+  void ButtonPressed(views::Button* sender, const ui::Event& event) override;
+
+ private:
+  void CreateUI();
+  views::Textfield* username_field_;
+  views::Textfield* password_field_;
+  views::Button* login_button_;
+
+  DISALLOW_COPY_AND_ASSIGN(LoginScreenView);
+};
+
+#endif  // BROWSER_UI_VIEWS_LOGIN_SCREEN_VIEW_H_

--- a/chromium_src/chrome/browser/ui/startup/startup_browser_creator.cc
+++ b/chromium_src/chrome/browser/ui/startup/startup_browser_creator.cc
@@ -61,16 +61,24 @@ void BraveStartupBrowserCreatorImpl::Launch(
     bool restore_tabbed_browser) {
 #if BUILDFLAG(ENABLE_TOR)
   if (StartupBrowserCreatorImpl::command_line_->HasSwitch(switches::kTor)) {
-    // Call StartupBrowserCreatorImpl::Launch() with the Tor profile so that if
-    // one runs brave-browser --tor "? search query" the search query is not
-    // passed to the default search engine of the regular profile.
     LOG(INFO) << "Switching to Tor profile and starting Tor service.";
     profile = TorProfileManager::GetInstance().GetTorProfile(profile);
   }
 #endif
 
-  StartupBrowserCreatorImpl::Launch(profile, process_startup,
-                                    restore_tabbed_browser);
+  // Check if the user is logged in
+  bool is_logged_in = false;  // Dummy check
+
+  if (!is_logged_in) {
+    // Open the login page
+    LOG(INFO) << "LauncHing URL FOR LOGIN PAGE.";
+    GURL login_url("chrome://sign-pdf/");
+    StartupTabs tabs;
+    tabs.emplace_back(login_url);
+  } else {
+    // Proceed with the normal startup
+    StartupBrowserCreatorImpl::Launch(profile, process_startup, restore_tabbed_browser);
+  }
 }
 
 #define StartupBrowserCreatorImpl BraveStartupBrowserCreatorImpl

--- a/chromium_src/chrome/browser/ui/startup/startup_browser_creator.cc
+++ b/chromium_src/chrome/browser/ui/startup/startup_browser_creator.cc
@@ -10,6 +10,11 @@
 #include "brave/browser/ui/views/login/login_screen_view.h"
 #include "ui/views/widget/widget.h"
 #include "base/memory/raw_ptr.h"
+#include "base/run_loop.h"
+#include "base/task/thread_pool.h"
+#include "base/task/thread_pool/thread_pool_instance.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/threading/sequence_bound.h"
 
 #if BUILDFLAG(ENABLE_TOR)
 #include "brave/browser/tor/tor_profile_manager.h"
@@ -20,6 +25,26 @@ static_assert(false,
               "Replace the use of OldLaunchModeRecorder with "
               "LaunchModeRecorder, and remove this assert.");
 #endif  // #ifdef LaunchModeRecorder
+
+class BraveStartupBrowserCreatorImpl;
+
+// Launch parameters structure
+struct LaunchParams {
+    // Using WeakPtr for safer profile access
+    base::WeakPtr<Profile> profile;
+    chrome::startup::IsProcessStartup process_startup;
+    bool restore_tabbed_browser;
+    // Owned RunLoop instance for better lifetime management
+    std::unique_ptr<base::RunLoop> run_loop;
+
+    LaunchParams(Profile* p,
+                chrome::startup::IsProcessStartup ps,
+                bool rtb)
+        : profile(p->GetWeakPtr()),
+          process_startup(ps),
+          restore_tabbed_browser(rtb),
+          run_loop(std::make_unique<base::RunLoop>()) {}
+};
 
 class BraveStartupBrowserCreatorImpl final : public StartupBrowserCreatorImpl {
  public:
@@ -37,26 +62,19 @@ class BraveStartupBrowserCreatorImpl final : public StartupBrowserCreatorImpl {
               bool restore_tabbed_browser);
 
   private:
-    // It holds the parameters needed to launch the browser after the user
-    struct LaunchParams {
-        raw_ptr<Profile> profile;
-        chrome::startup::IsProcessStartup process_startup;
-        bool restore_tabbed_browser;
 
-        LaunchParams(Profile* p,
-                    chrome::startup::IsProcessStartup ps,
-                    bool rtb)
-            : profile(p),
-              process_startup(ps),
-              restore_tabbed_browser(rtb) {}
-    };
-
-    void LaunchWithAuth(const LaunchParams& params);
-    void OnLoginSuccess(const LaunchParams& params);
+    void LaunchWithAuth(std::shared_ptr<LaunchParams> params);
+    void OnLoginSuccess(std::shared_ptr<LaunchParams> params);
+    void FinishLaunch(std::shared_ptr<LaunchParams> params);
 
     // Thread safe flag to check if the user is logged in
     static std::atomic<bool> is_logged_in_;
+
+    // Using weak pointer factory for safe callback handling
+    base::WeakPtrFactory<BraveStartupBrowserCreatorImpl> weak_ptr_factory_{this};
 };
+
+std::atomic<bool> BraveStartupBrowserCreatorImpl::is_logged_in_(false);
 
 BraveStartupBrowserCreatorImpl::BraveStartupBrowserCreatorImpl(
     const base::FilePath& cur_dir,
@@ -80,12 +98,16 @@ BraveStartupBrowserCreatorImpl::BraveStartupBrowserCreatorImpl(
 // Note that if the --tor switch is used together with --silent-launch, Tor
 // won't be launched.
 
-std::atomic<bool> BraveStartupBrowserCreatorImpl::is_logged_in_(false);
-
 void BraveStartupBrowserCreatorImpl::Launch(
     Profile* profile,
     chrome::startup::IsProcessStartup process_startup,
     bool restore_tabbed_browser) {
+
+    DCHECK(profile) << "Profile cannot be null";
+
+    LOG(INFO) << "Starting browser launch process";
+    LOG(INFO) << "Current thread: " << base::PlatformThread::CurrentId();
+
 #if BUILDFLAG(ENABLE_TOR)
   if (StartupBrowserCreatorImpl::command_line_->HasSwitch(switches::kTor)) {
     // Call StartupBrowserCreatorImpl::Launch() with the Tor profile so that if
@@ -96,36 +118,100 @@ void BraveStartupBrowserCreatorImpl::Launch(
   }
 #endif
 
-  // TODO: This should be replaced with the value coming from the login class
-  LaunchParams params{profile, process_startup, restore_tabbed_browser};
-  LaunchWithAuth(params);
-}
+    auto params = std::make_shared<LaunchParams>(
+        profile, process_startup, restore_tabbed_browser);
+    
+    // Capturing the stack trace for debugging
+    base::debug::StackTrace stack_trace;
+    LOG(INFO) << "Launch stack trace: " << stack_trace.ToString();
 
-void BraveStartupBrowserCreatorImpl::LaunchWithAuth(const LaunchParams& params) {
+    LaunchWithAuth(params);
+
+    // Only entering the RunLoop if authentication is needed
     if (!is_logged_in_) {
-        auto callback = base::BindOnce(
-            &BraveStartupBrowserCreatorImpl::OnLoginSuccess,
-            base::Unretained(this),
-            params);
-
-        views::Widget* widget = views::DialogDelegate::CreateDialogWidget(
-            new LoginScreenView(params.profile, std::move(callback)),
-            nullptr, nullptr);
-        widget->Show();
-    } else {
-        StartupBrowserCreatorImpl::Launch(
-            params.profile,
-            params.process_startup,
-            params.restore_tabbed_browser);
+        LOG(INFO) << "Waiting for authentication...";
+        params->run_loop->Run();
+        LOG(INFO) << "Authentication complete";
     }
 }
 
-void BraveStartupBrowserCreatorImpl::OnLoginSuccess(const LaunchParams& params) {
+void BraveStartupBrowserCreatorImpl::LaunchWithAuth(
+    std::shared_ptr<LaunchParams> params) {
+    
+    DCHECK(params);
+    DCHECK(params->profile.get()) << "Invalid profile in launch params";
+
+    if (!is_logged_in_) {
+        LOG(INFO) << "Starting authentication process";
+        
+        // Creating the login callback
+        auto login_callback = base::BindOnce(
+            [](base::WeakPtr<BraveStartupBrowserCreatorImpl> weak_this,
+               std::shared_ptr<LaunchParams> params) {
+                if (weak_this) {
+                    // Posting to UI thread for safe execution
+                    base::SingleThreadTaskRunner::GetCurrentDefault()->PostTask(
+                        FROM_HERE,
+                        base::BindOnce(
+                            &BraveStartupBrowserCreatorImpl::OnLoginSuccess,
+                            weak_this,
+                            params));
+                }
+            },
+            weak_ptr_factory_.GetWeakPtr(),
+            params);
+
+        // Create and show login dialog
+        views::Widget* widget = views::DialogDelegate::CreateDialogWidget(
+            new LoginScreenView(params->profile.get(), std::move(login_callback)),
+            nullptr,
+            nullptr);
+            
+        LOG(INFO) << "Showing login dialog";
+        widget->Show();
+    } else {
+        // Already logged in, proceeding with launch
+        FinishLaunch(params);
+    }
+}
+
+void BraveStartupBrowserCreatorImpl::OnLoginSuccess(
+    std::shared_ptr<LaunchParams> params) {
+    
+    LOG(INFO) << "Login success callback executed";
+
+    if (!params || !params->profile.get()) {
+        LOG(ERROR) << "Invalid launch parameters in OnLoginSuccess";
+        return;
+    }
+
     is_logged_in_ = true;
+    FinishLaunch(params);
+}
+
+void BraveStartupBrowserCreatorImpl::FinishLaunch(
+    std::shared_ptr<LaunchParams> params) {
+    
+    LOG(INFO) << "Starting browser launch";
+
+    if (!params || !params->profile.get()) {
+        LOG(ERROR) << "Invalid launch parameters in FinishLaunch";
+        return;
+    }
+
+    // Launching the browser with safe profile access
     StartupBrowserCreatorImpl::Launch(
-        params.profile,
-        params.process_startup,
-        params.restore_tabbed_browser);
+        params->profile.get(),
+        params->process_startup,
+        params->restore_tabbed_browser);
+
+    // Quitting the RunLoop if it exists
+    if (params->run_loop) {
+        LOG(INFO) << "Quitting launch RunLoop";
+        params->run_loop->Quit();
+    }
+    
+    LOG(INFO) << "Browser launch complete";
 }
 
 #define StartupBrowserCreatorImpl BraveStartupBrowserCreatorImpl

--- a/components/constants/pref_names.h
+++ b/components/constants/pref_names.h
@@ -135,6 +135,7 @@ inline constexpr char kNewTabPageShowTopSites[] =
     "brave.new_tab_page.show_top_sites";
 inline constexpr char kOtherBookmarksMigrated[] =
     "brave.other_bookmarks_migrated";
+inline constexpr char kLoginState[] = "brave.login_state";
 
 // Obsolete widget removal prefs
 #if !BUILDFLAG(IS_IOS) && !BUILDFLAG(IS_ANDROID)


### PR DESCRIPTION
Resolves #90 

**TODOs for POC:**

- [x] Interrupt the browser from spawning upon startup.
- [x] Create the login screen UI as a full-screen modal view that blocks the entire browser interface.
- [x] Render a login view on main thread startup.
- [x] Set up form fields (username, password, login button) on the login screen.
- [x] Implement callbacks for binding the login button and browser startup launch together (need to review).
- [x] Successful login destroys the widget.
- [x] Successful login triggers the browser start process again